### PR TITLE
Parse body as JSON when content-type is JSON

### DIFF
--- a/lib/server.ts
+++ b/lib/server.ts
@@ -25,6 +25,11 @@ class Server extends Router {
         })
         .on('end', async () => {
           req.body = Buffer.concat(reqbody).toString();
+
+          if (req.headers['content-type'] === 'application/json') {
+            req.body = JSON.parse(req.body);
+          }
+
           injectRequest(req);
           injectResponse(res);
           await this.handle(req, res);


### PR DESCRIPTION
This fixes https://github.com/skuyjs/http-server/issues/5. It will check for the Content-Type header, and if it is application/json, it parses the JSON.