### PR TITLE
Add redirect response (fixes #7)

### DIFF
--- a/examples/redirect.js
+++ b/examples/redirect.js
@@ -1,0 +1,18 @@
+const Server = require('../dist');
+const server = new Server();
+
+server.get('/', (req, res) => {
+  res.json({
+    message: 'welcome'
+  });
+});
+
+server.get('/redirect', (req, res) => {
+  res.redirect('/');
+});
+
+server.get('/redirect-301', (req, res) => {
+  res.redirect('/', 301);
+});
+
+server.listen(8080);

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -46,4 +46,20 @@ export = function injectResponse(res: Res) {
     const json = typeof param === 'object' ? JSON.stringify(param) : param;
     sendByType('application/json', json);
   };
+
+  /**
+   * Send redirect response
+   * @param url redirect path
+   * @param code redirect status code, default to 302
+   */
+  res.redirect = (url: string, code: number = 302) => {
+    // tslint:disable-next-line: strict-type-predicates
+    if (![301, 302].includes(code) && process.env.NODE_ENV === 'development') {
+      console.log('Cannot set status code with given code');
+    }
+
+    res.statusCode = code;
+    res.setHeader('Location', url);
+    res.end();
+  }
 };

--- a/lib/typings/res.ts
+++ b/lib/typings/res.ts
@@ -4,4 +4,5 @@ export interface Res extends ServerResponse {
   status(code: number): Res;
   send(param: any): void;
   json(object: object): void;
+  redirect(url: string, code: number): void;
 }


### PR DESCRIPTION
This PR implements simple redirect response, with ability to choose HTTP status code used for redirection between `301 Moved Permanently` or `302 Found` on the optional second parameter (default to `302`).